### PR TITLE
fix: 修复了Bot在早安和晚安时的意外输出

### DIFF
--- a/main.py
+++ b/main.py
@@ -496,15 +496,14 @@ class Main(Star):
         curr_date_str = curr_utc8.strftime("%Y-%m-%d")
 
         self.invalidate_sleep_cache(umo_id, curr_date_str)
+        
         curr_day_sleeping = 0
+        curr_date_prefix = curr_utc8.strftime("%Y-%m-%d") # 获取今天的日期
         for v in umo.values():
-            if v["daily"]["night_time"] and not v["daily"]["morning_time"]:
-                # he/she is sleeping
-                user_day = datetime.datetime.strptime(
-                    v["daily"]["night_time"], "%Y-%m-%d %H:%M:%S"
-                ).day
-                if user_day == curr_day:
-                    curr_day_sleeping += 1
+            n_time = v["daily"]["night_time"]
+            if n_time and n_time.startswith(curr_date_prefix):
+                # 只要晚安是今天，就代表今天睡了一个
+                curr_day_sleeping += 1
         
         # 更新缓存为最新计算结果
         self.update_sleep_cache(umo_id, curr_date_str, curr_day_sleeping)
@@ -524,10 +523,17 @@ class Main(Star):
                 mins = int((sleep_duration % 3600) / 60)
                 sleep_duration_human = f"{hrs}小时{mins}分"
 
+            good_moring_text = ""
+
+            if sleep_duration_human:
+                good_moring_text = f"早上好喵，{user_name}！\n现在是 {curr_human}，昨晚你睡了 {sleep_duration_human}。"
+            else:
+                good_moring_text = f"早上好喵，{user_name}！\n现在是 {curr_human}，昨晚似乎没说晚安呢~"
+
             return (
                 CommandResult()
                 .message(
-                    f"早上好喵，{user_name}！\n现在是 {curr_human}，昨晚你睡了 {sleep_duration_human}。"
+                    good_moring_text
                 )
                 .use_t2i(False)
             )


### PR DESCRIPTION
本Pr修复了两个Bot意外输出：

1. 向bot说早安时，如果昨晚没有说过晚安，Bot仍会选择输出`昨晚你睡了 `的内容，本pr将其视作另外一种特殊情况，使用修改后的文本进行回复。
2. 向bot说晚安时，由于当前版本的Bot对晚安排序条件极为严格，导致经常出现所有人都是第一个睡的情况，本pr对其进行了适当放宽，只要说了晚安就记入一个睡觉人数。

由于我没有一个qqbot可用于测试，以下代码均未经过实际测试。