### PR TITLE
feat: 增加早晚安功能开关（good_morning_enabled）

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -4,5 +4,11 @@
     "type": "int",
     "default": 65,
     "hint": "用于调整喜报和悲报的字体大小，默认值为65"
+  },
+  "good_morning_enabled": {
+    "description": "是否启用早安/晚安睡眠记录",
+    "type": "bool",
+    "default": true,
+    "hint": "关闭后将不响应“早安/晚安”并停止记录睡眠数据"
   }
 }

--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ class Main(Star):
 
         self.search_anmime_demand_users = {}
         self.daily_sleep_cache = {}
-        self.good_morning_cd = {} 
+        self.good_morning_cd = {}
 
     def _get_report_font_size(self) -> int:
         size = self.config.get("report_font_size", 65)
@@ -59,10 +59,20 @@ class Main(Star):
             return 65
         return size if size > 0 else 65
 
+    def _is_good_morning_enabled(self) -> bool:
+        value = self.config.get("good_morning_enabled", True)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return value != 0
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return True
+
     def time_convert(self, t):
         m, s = divmod(t, 60)
         return f"{int(m)}分{int(s)}秒"
-    
+
     def get_cached_sleep_count(self, umo_id: str, date_str: str) -> int:
         """获取缓存的睡觉人数"""
         if umo_id not in self.daily_sleep_cache:
@@ -76,15 +86,20 @@ class Main(Star):
         self.daily_sleep_cache[umo_id][date_str] = count
 
     def invalidate_sleep_cache(self, umo_id: str, date_str: str):
-            """使缓存失效"""
-            if umo_id in self.daily_sleep_cache and date_str in self.daily_sleep_cache[umo_id]:
-                del self.daily_sleep_cache[umo_id][date_str]
+        """使缓存失效"""
+        if (
+            umo_id in self.daily_sleep_cache
+            and date_str in self.daily_sleep_cache[umo_id]
+        ):
+            del self.daily_sleep_cache[umo_id][date_str]
 
-    def check_good_morning_cd(self, user_id: str, current_time: datetime.datetime) -> bool:
+    def check_good_morning_cd(
+        self, user_id: str, current_time: datetime.datetime
+    ) -> bool:
         """检查用户是否在CD中，返回True表示在CD中"""
         if user_id not in self.good_morning_cd:
             return False
-        
+
         last_time = self.good_morning_cd[user_id]
         time_diff = (current_time - last_time).total_seconds()
         return time_diff < 1800  # 硬编码30分钟
@@ -449,16 +464,25 @@ class Main(Star):
     @filter.regex(r"^(早安|晚安)")
     async def good_morning(self, message: AstrMessageEvent):
         """和Bot说早晚安，记录睡眠时间，培养良好作息"""
+        if not self._is_good_morning_enabled():
+            return
+
         # CREDIT: 灵感部分借鉴自：https://github.com/MinatoAquaCrews/nonebot_plugin_morning
         umo_id = message.unified_msg_origin
         user_id = message.message_obj.sender.user_id
         user_name = message.message_obj.sender.nickname
-        curr_utc8 = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=8)))
+        curr_utc8 = datetime.datetime.now(
+            datetime.timezone(datetime.timedelta(hours=8))
+        )
         curr_human = curr_utc8.strftime("%Y-%m-%d %H:%M:%S")
 
         # 检查CD
         if self.check_good_morning_cd(user_id, curr_utc8):
-            return CommandResult().message("你刚刚已经说过早安/晚安了，请30分钟后再试喵~").use_t2i(False)
+            return (
+                CommandResult()
+                .message("你刚刚已经说过早安/晚安了，请30分钟后再试喵~")
+                .use_t2i(False)
+            )
 
         is_night = "晚安" in message.message_str
 
@@ -487,7 +511,7 @@ class Main(Star):
 
         with open(f"data/{self.PLUGIN_NAME}_data.json", "w", encoding="utf-8") as f:
             f.write(json.dumps(self.good_morning_data, ensure_ascii=False, indent=2))
-            
+
         # 更新CD
         self.update_good_morning_cd(user_id, curr_utc8)
 
@@ -505,7 +529,7 @@ class Main(Star):
                 ).day
                 if user_day == curr_day:
                     curr_day_sleeping += 1
-        
+
         # 更新缓存为最新计算结果
         self.update_sleep_cache(umo_id, curr_date_str, curr_day_sleeping)
 


### PR DESCRIPTION
## 变更说明

本 PR 为 `astrbot_plugin_essential` 增加了“早安/晚安”功能开关，便于在不删除功能代码的前提下按需启用或禁用睡眠记录能力。

## 主要改动

1. 新增配置项 `good_morning_enabled`
- 文件：`_conf_schema.json`
- 类型：`bool`
- 默认值：`true`
- 说明：关闭后不响应“早安/晚安”，并停止记录睡眠数据

2. 新增开关读取逻辑
- 文件：`main.py`
- 新增方法：`_is_good_morning_enabled()`
- 兼容多种配置值（`bool` / 数字 / 字符串）

3. 接入早晚安入口判断
- 文件：`main.py`
- 在 `good_morning` 处理函数开头增加判断：
  - 当开关为 `false` 时，直接返回
  - 不产生回复，不写入睡眠记录

## 行为变化

- `good_morning_enabled = true`（默认）：行为与之前一致
- `good_morning_enabled = false`：禁用早安/晚安相关响应与记录

## 兼容性与影响范围

- 仅影响“早安/晚安”功能
- 其他命令（如喜报、悲报、moe、搜番等）不受影响

## 自测

- [x] 开关为 `true` 时，早安/晚安可正常触发并记录
- [x] 开关为 `false` 时，早安/晚安不响应、不记录
- [x] 插件加载正常，无新增配置解析错误
